### PR TITLE
Record audio by ALSA

### DIFF
--- a/audiofifo.go
+++ b/audiofifo.go
@@ -1,0 +1,100 @@
+/*
+Copyright (c) 2015, EMSYM Corporation
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of EMSYM Corporation nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+
+Sleepy Programmer <hunan@emsym.com>
+
+*/
+
+package gmf
+
+/*
+#cgo pkg-config: libavutil
+#include <libavutil/audio_fifo.h>
+#include <libavutil/frame.h>
+
+int write_fifo(AVAudioFifo* fifo, AVFrame* frame, int nb_samples){
+	return av_audio_fifo_write(fifo,(void**)frame->data,nb_samples);
+}
+
+int read_fifo(AVAudioFifo* fifo, AVFrame* frame, int nb_samples){
+	return av_audio_fifo_read(fifo,(void**)frame->data,nb_samples);
+}
+*/
+import "C"
+
+type AVAudioFifo struct {
+	avAudioFifo  *C.struct_AVAudioFifo
+	sampleFormat int32
+	channels     int
+}
+
+func NewAVAudioFifo(sampleFormat int32, channels int, nb_samples int) *AVAudioFifo {
+	fifo := C.av_audio_fifo_alloc(sampleFormat, C.int(channels), C.int(nb_samples))
+	if fifo == nil {
+		return nil
+	}
+
+	return &AVAudioFifo{
+		avAudioFifo:  fifo,
+		sampleFormat: sampleFormat,
+		channels:     channels,
+	}
+}
+
+func (this *AVAudioFifo) SamplesToRead() int {
+	return int(C.av_audio_fifo_size(this.avAudioFifo))
+}
+func (this *AVAudioFifo) SamplesCanWrite() int {
+	return int(C.av_audio_fifo_space(this.avAudioFifo))
+}
+func (this *AVAudioFifo) Write(frame *Frame) int {
+	return int(C.write_fifo(this.avAudioFifo,
+		frame.avFrame,
+		C.int(frame.NbSamples())))
+}
+func (this *AVAudioFifo) Read(sampleCount int) *Frame {
+	rsize := this.SamplesToRead()
+	size := rsize
+	if sampleCount <= rsize {
+		size = sampleCount
+	}
+	frame, err := NewAudioFrame(this.sampleFormat, this.channels, size)
+	if frame == nil || err != nil {
+		return nil
+	}
+	if int(C.read_fifo(this.avAudioFifo,
+		frame.avFrame,
+		C.int(size))) == size {
+		return frame
+	} else {
+		frame.Release()
+		return nil
+	}
+}
+
+func (this *AVAudioFifo) Free() {
+	C.av_audio_fifo_free(this.avAudioFifo)
+}

--- a/examples/alsa_record.go
+++ b/examples/alsa_record.go
@@ -1,0 +1,132 @@
+/*
+Copyright (c) 2015, EMSYM Corporation
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of EMSYM Corporation nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+
+Sleepy Programmer <hunan@emsym.com>
+
+*/
+
+package main
+
+import (
+	. "github.com/3d0c/gmf"
+	"log"
+)
+
+func main() {
+	/// input
+	mic, _ := NewInputCtxWithFormatName("default", "alsa")
+	mic.Dump()
+
+	ast, err := mic.GetBestStream(AVMEDIA_TYPE_AUDIO)
+	if err != nil {
+		log.Fatal("failed to find audio stream")
+	}
+	cc := ast.CodecCtx()
+
+	/// fifo
+	fifo := NewAVAudioFifo(cc.SampleFmt(), cc.Channels(), 1024)
+	if fifo == nil {
+		log.Fatal("failed to create audio fifo")
+	}
+
+	/// output
+	codecName := ""
+	switch cc.SampleFmt() {
+	case AV_SAMPLE_FMT_S16:
+		codecName = "pcm_s16le"
+	default:
+		log.Fatal("sample format not support")
+	}
+	codec, err := FindEncoder(codecName)
+	if err != nil {
+		log.Fatal("find encoder error:", err.Error())
+	}
+
+	occ := NewCodecCtx(codec)
+	if occ == nil {
+		log.Fatal("new output codec context error:", err.Error())
+	}
+	defer Release(occ)
+
+	occ.SetSampleFmt(cc.SampleFmt()).
+		SetSampleRate(cc.SampleRate()).
+		SetChannels(cc.Channels())
+
+	if err := occ.Open(nil); err != nil {
+		log.Fatal("can't open output codec context", err.Error())
+		return
+	}
+	outputCtx, err := NewOutputCtx("test.wav")
+	if err != nil {
+		log.Fatal("new output fail", err.Error())
+		return
+	}
+
+	ost := outputCtx.NewStream(codec)
+	if ost == nil {
+		log.Fatal("Unable to create stream for [%s]\n", codec.LongName())
+	}
+	defer Release(ost)
+
+	ost.SetCodecCtx(occ)
+
+	if err := outputCtx.WriteHeader(); err != nil {
+		log.Fatal(err.Error())
+	}
+
+	count := 0
+	for packet := range mic.GetNewPackets() {
+		srcFrame, got, ret, err := packet.DecodeToNewFrame(ast.CodecCtx())
+		Release(packet)
+		if !got || ret < 0 || err != nil {
+			log.Println("capture audio error:", err)
+			continue
+		}
+
+		wrote := fifo.Write(srcFrame)
+		count += wrote
+
+		for fifo.SamplesToRead() >= 1152 {
+			dstFrame := fifo.Read(1152)
+			if dstFrame == nil {
+				continue
+			}
+
+			writePacket, ready, _ := dstFrame.EncodeNewPacket(occ)
+			if ready {
+				if err := outputCtx.WritePacket(writePacket); err != nil {
+					log.Println("write packet err", err.Error())
+				}
+
+				Release(writePacket)
+			}
+		}
+		if count > int(cc.SampleRate())*10 {
+			break
+		}
+		Release(srcFrame)
+	}
+}

--- a/format.go
+++ b/format.go
@@ -3,10 +3,11 @@ package gmf
 
 /*
 
-#cgo pkg-config: libavformat
+#cgo pkg-config: libavformat libavdevice
 
 #include <stdlib.h>
 #include "libavformat/avformat.h"
+#include <libavdevice/avdevice.h>
 #include "libavutil/opt.h"
 
 static AVStream* gmf_get_stream(AVFormatContext *ctx, int idx) {
@@ -69,6 +70,7 @@ type FmtCtx struct {
 func init() {
 	C.av_register_all()
 	C.avformat_network_init()
+	C.avdevice_register_all()
 }
 
 // @todo return error if avCtx is null
@@ -154,6 +156,20 @@ func NewInputCtx(filename string) (*FmtCtx, error) {
 	return ctx, nil
 }
 
+func NewInputCtxWithFormatName(filename, format string) (*FmtCtx, error) {
+	ctx := NewCtx()
+
+	if ctx.avCtx == nil {
+		return nil, errors.New(fmt.Sprintf("unable to allocate context"))
+	}
+	if err := ctx.SetInputFormat(format); err != nil {
+		return nil, err
+	}
+	if err := ctx.OpenInput(filename); err != nil {
+		return nil, err
+	}
+	return ctx, nil
+}
 func (this *FmtCtx) OpenInput(filename string) error {
 	var cfilename *_Ctype_char
 

--- a/frame.go
+++ b/frame.go
@@ -170,6 +170,33 @@ func (this *Frame) ImgAlloc() error {
 	return nil
 }
 
+func NewAudioFrame(sampleFormat int32, channels, nb_samples int) (*Frame, error) {
+	this := NewFrame()
+	this.mediaType = AVMEDIA_TYPE_AUDIO
+	this.SetNbSamples(nb_samples)
+	this.SetFormat(sampleFormat)
+	this.SetChannelLayout(channels)
+
+	//the codec gives us the frame size, in samples,
+	//we calculate the size of the samples buffer in bytes
+	size := C.av_samples_get_buffer_size(nil, C.int(channels), C.int(nb_samples),
+		sampleFormat, 0)
+	if size < 0 {
+		return nil, errors.New("Could not get sample buffer size")
+	}
+	samples := (*_Ctype_uint8_t)(C.av_malloc(C.size_t(size)))
+	if samples == nil {
+		return nil, errors.New(fmt.Sprintf("Could not allocate %d bytes for samples buffer", size))
+	}
+
+	//setup the data pointers in the AVFrame
+	ret := int(C.avcodec_fill_audio_frame(this.avFrame, C.int(channels), sampleFormat,
+		samples, C.int(size), 0))
+	if ret < 0 {
+		return nil, errors.New("Could not setup audio frame")
+	}
+	return this, nil
+}
 func (this *Frame) SetData(idx int, lineSize int, data int) *Frame {
 	C.gmf_set_frame_data(this.avFrame, C.int(idx), C.int(lineSize), (_Ctype_uint8_t)(data))
 

--- a/packet.go
+++ b/packet.go
@@ -81,7 +81,7 @@ func (this *Packet) Decode(cc *CodecCtx) (*Frame, bool, int, error) {
 
 func (this *Packet) DecodeToNewFrame(cc *CodecCtx) (*Frame, bool, int, error) {
 	f := &Frame{avFrame: C.av_frame_alloc(), mediaType: cc.Type()}
-	this.decode(cc, f)
+	return this.decode(cc, f)
 }
 
 func (this *Packet) decode(cc *CodecCtx, frame *Frame) (*Frame, bool, int, error) {


### PR DESCRIPTION
An example program: Record audio by ALSA and write .wav file
    
    1. Modify the input context. Construct audio input from ALSA
    2. Add AVAudioFifo class.
    3. An example.