### PR TITLE
Match int64 usage of ffmpeg

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -26,7 +26,7 @@ var (
 	AV_PIX_FMT_RGB24        int32 = C.AV_PIX_FMT_RGB24
 	AV_PIX_FMT_NONE         int32 = C.AV_PIX_FMT_NONE
 	FF_PROFILE_MPEG4_SIMPLE int   = C.FF_PROFILE_MPEG4_SIMPLE
-	AV_NOPTS_VALUE          int   = C.AV_NOPTS_VALUE
+	AV_NOPTS_VALUE          int64 = C.AV_NOPTS_VALUE
 )
 
 func init() {

--- a/format.go
+++ b/format.go
@@ -416,7 +416,7 @@ func (this *FmtCtx) SetFlag(flag int) *FmtCtx {
 	return this
 }
 
-func (this *FmtCtx) SeekFile(ist *Stream, minTs, maxTs int, flag int) error {
+func (this *FmtCtx) SeekFile(ist *Stream, minTs, maxTs int64, flag int) error {
 	if ret := int(C.avformat_seek_file(this.avCtx, C.int(ist.Index()), C.int64_t(0), C.int64_t(minTs), C.int64_t(maxTs), C.int(flag))); ret < 0 {
 		return errors.New(fmt.Sprintf("Error creating output context: %s", AvError(ret)))
 	}
@@ -424,13 +424,13 @@ func (this *FmtCtx) SeekFile(ist *Stream, minTs, maxTs int, flag int) error {
 	return nil
 }
 
-func (this *FmtCtx) SeekFrameAt(sec int, streamIndex int) error {
+func (this *FmtCtx) SeekFrameAt(sec int64, streamIndex int) error {
 	ist, err := this.GetStream(streamIndex)
 	if err != nil {
 		return err
 	}
 
-	frameTs := Rescale(sec*1000, ist.TimeBase().AVR().Den, ist.TimeBase().AVR().Num) / 1000
+	frameTs := Rescale(sec*1000, int64(ist.TimeBase().AVR().Den), int64(ist.TimeBase().AVR().Num)) / 1000
 
 	if err := this.SeekFile(ist, frameTs, frameTs, C.AVSEEK_FLAG_FRAME); err != nil {
 		return err

--- a/format_test.go
+++ b/format_test.go
@@ -185,7 +185,7 @@ func TestAVIOContext(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ictx.SetPb(avioCtx).SetFlag(AV_NOPTS_VALUE).OpenInput("")
+	ictx.SetPb(avioCtx).OpenInput("")
 
 	for p := range ictx.GetNewPackets() {
 		_ = p
@@ -213,7 +213,7 @@ func ExampleNewAVIOContext(t *testing.T) {
 	}
 
 	// Setting up AVFormatContext.pb
-	ctx.SetPb(avioCtx).SetFlag(AV_NOPTS_VALUE)
+	ctx.SetPb(avioCtx)
 
 	// Calling OpenInput with empty arg, because all files stuff we're doing in custom reader.
 	// But the library have to initialize some stuff, so we call it anyway.

--- a/frame.go
+++ b/frame.go
@@ -75,15 +75,15 @@ func encode(cc *CodecCtx, avFrame *C.struct_AVFrame, mediaType int32) (*Packet, 
 	return p, (gotOutput > 0), nil
 }
 
-func (this *Frame) Pts() int {
-	return int(this.avFrame.pts)
+func (this *Frame) Pts() int64 {
+	return int64(this.avFrame.pts)
 }
 
 func (this *Frame) Unref() {
 	C.av_frame_unref(this.avFrame)
 }
 
-func (this *Frame) SetPts(val int) {
+func (this *Frame) SetPts(val int64) {
 	this.avFrame.pts = (_Ctype_int64_t)(val)
 }
 
@@ -104,11 +104,11 @@ func (this *Frame) Height() int {
 	return int(this.avFrame.height)
 }
 
-func (this *Frame) PktPts() int {
-	return int(this.avFrame.pkt_pts)
+func (this *Frame) PktPts() int64 {
+	return int64(this.avFrame.pkt_pts)
 }
 
-func (this *Frame) SetPktPts(val int) {
+func (this *Frame) SetPktPts(val int64) {
 	this.avFrame.pkt_pts = (_Ctype_int64_t)(val)
 }
 

--- a/packet.go
+++ b/packet.go
@@ -140,19 +140,19 @@ func (this *Packet) Frames(cc *CodecCtx) chan *Frame {
 	return yield
 }
 
-func (this *Packet) Pts() int {
-	return int(this.avPacket.pts)
+func (this *Packet) Pts() int64 {
+	return int64(this.avPacket.pts)
 }
 
-func (this *Packet) SetPts(pts int) {
+func (this *Packet) SetPts(pts int64) {
 	this.avPacket.pts = C.int64_t(pts)
 }
 
-func (this *Packet) Dts() int {
-	return int(this.avPacket.dts)
+func (this *Packet) Dts() int64 {
+	return int64(this.avPacket.dts)
 }
 
-func (this *Packet) SetDts(val int) {
+func (this *Packet) SetDts(val int64) {
 	this.avPacket.dts = _Ctype_int64_t(val)
 }
 
@@ -172,8 +172,8 @@ func (this *Packet) Size() int {
 	return int(this.avPacket.size)
 }
 
-func (this *Packet) Pos() int {
-	return int(this.avPacket.pos)
+func (this *Packet) Pos() int64 {
+	return int64(this.avPacket.pos)
 }
 
 func (this *Packet) Data() []byte {

--- a/stream.go
+++ b/stream.go
@@ -16,7 +16,7 @@ import (
 type Stream struct {
 	avStream *C.struct_AVStream
 	cc       *CodecCtx
-	Pts      int
+	Pts      int64
 	CgoMemoryManage
 }
 

--- a/utils.go
+++ b/utils.go
@@ -48,20 +48,20 @@ func AvError(averr int) error {
 	return errors.New(string(b[:bytes.Index(b, []byte{0})]))
 }
 
-func RescaleQ(a int, encBase AVRational, stBase AVRational) int {
-	return int(C.av_rescale_q(C.int64_t(a), C.struct_AVRational(encBase), C.struct_AVRational(stBase)))
+func RescaleQ(a int64, encBase AVRational, stBase AVRational) int64 {
+	return int64(C.av_rescale_q(C.int64_t(a), C.struct_AVRational(encBase), C.struct_AVRational(stBase)))
 }
 
 func CompareTimeStamp(aTimestamp int, aTimebase AVRational, bTimestamp int, bTimebase AVRational) int {
 	return int(C.av_compare_ts(C.int64_t(aTimestamp), C.struct_AVRational(aTimebase),
 		C.int64_t(bTimestamp), C.struct_AVRational(bTimebase)))
 }
-func RescaleDelta(inTb AVRational, inTs int, fsTb AVRational, duration int, last *int, outTb AVRational) int {
-	return int(C.av_rescale_delta(C.struct_AVRational(inTb), C.int64_t(inTs), C.struct_AVRational(fsTb), C.int(duration), (*C.int64_t)(unsafe.Pointer(&last)), C.struct_AVRational(outTb)))
+func RescaleDelta(inTb AVRational, inTs int64, fsTb AVRational, duration int, last *int64, outTb AVRational) int64 {
+	return int64(C.av_rescale_delta(C.struct_AVRational(inTb), C.int64_t(inTs), C.struct_AVRational(fsTb), C.int(duration), (*C.int64_t)(unsafe.Pointer(&last)), C.struct_AVRational(outTb)))
 }
 
-func Rescale(a, b, c int) int {
-	return int(C.av_rescale(C.int64_t(a), C.int64_t(b), C.int64_t(c)))
+func Rescale(a, b, c int64) int64 {
+	return int64(C.av_rescale(C.int64_t(a), C.int64_t(b), C.int64_t(c)))
 }
 
 func GetSampleFmtName(fmt int32) string {


### PR DESCRIPTION
Should't use int, since its size depends on architecture.