### PR TITLE
Add synchronous version of NewPacket and Frame methods.

### DIFF
--- a/format.go
+++ b/format.go
@@ -293,6 +293,19 @@ func (this *FmtCtx) DumpAv() {
 	fmt.Println("flags:", this.avCtx.flags)
 }
 
+func (this *FmtCtx) GetNextPacket() *Packet {
+	p := NewPacket()
+	for {
+
+		if ret := C.av_read_frame(this.avCtx, &p.avPacket); int(ret) < 0 {
+			Release(p)
+			return nil
+		}
+
+		return p
+	}
+}
+
 func (this *FmtCtx) GetNewPackets() chan *Packet {
 	yield := make(chan *Packet)
 

--- a/format_test.go
+++ b/format_test.go
@@ -141,6 +141,23 @@ func TestPacketsIterator(t *testing.T) {
 	}
 }
 
+func TestGetNextPacket(t *testing.T) {
+	inputCtx, err := NewInputCtx(inputSampleFilename)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer inputCtx.CloseInputAndRelease()
+
+	packet := inputCtx.GetNextPacket()
+	if packet.Size() <= 0 {
+		t.Fatal("Expected size > 0")
+	} else {
+		log.Printf("One packet has been read. size: %v, pts: %v\n", packet.Size(), packet.Pts())
+	}
+	Release(packet)
+}
+
 var section *io.SectionReader
 
 func customReader() ([]byte, int) {

--- a/packet.go
+++ b/packet.go
@@ -114,21 +114,23 @@ func (this *Packet) decode(cc *CodecCtx, frame *Frame) (*Frame, bool, int, error
 
 func (this *Packet) GetNextFrame(cc *CodecCtx) (*Frame, error) {
 	for {
-		frame, ready, ret, err := this.DecodeToNewFrame(cc)
-		if ready {
-			return frame, nil
+		if this.avPacket.size <= 0 {
+			break
 		}
 
-		Release(frame)
+		frame, ready, ret, err := this.DecodeToNewFrame(cc)
+		if !ready {
+			Release(frame)
 
-		if ret < 0 || err != nil {
-			return nil, err
+			if ret < 0 || err != nil {
+				return nil, err
+			}
 		}
 
 		C.shift_data(&this.avPacket, C.int(ret))
 
-		if this.avPacket.size <= 0 {
-			break
+		if ready {
+			return frame, nil
 		}
 	}
 

--- a/packet_test.go
+++ b/packet_test.go
@@ -35,3 +35,42 @@ func TestFramesIterator(t *testing.T) {
 	}
 
 }
+
+func TestGetNextFrame(t *testing.T) {
+	inputCtx, err := NewInputCtx(inputSampleFilename)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer inputCtx.CloseInputAndRelease()
+
+	for {
+		packet := inputCtx.GetNextPacket()
+		if packet == nil {
+			break
+		}
+		if packet.Size() <= 0 {
+			t.Fatal("Expected size > 0")
+		}
+
+		ist := assert(inputCtx.GetStream(0)).(*Stream)
+
+		f := 0
+		for {
+			frame, err := packet.GetNextFrame(ist.CodecCtx())
+			if frame == nil && err == nil {
+				break
+			}
+			Release(frame)
+			f++
+		}
+
+		if f >= 1 {
+			log.Println(f, "frames decode.")
+			Release(packet)
+			break
+		}
+
+		Release(packet)
+	}
+}


### PR DESCRIPTION
GetNewPackets() and Frames() methods are convenient when scanning all
frames, but not so when the caller leaves early in the loop, resulting
in goroutine leak.  Even more, Frames() method currently uses global
decode frame object that is shared among concurrent access.