### PR TITLE
examples: Fix compilation error in transcode

### DIFF
--- a/examples/transcode.go
+++ b/examples/transcode.go
@@ -76,7 +76,7 @@ func addStream(codecName string, oc *FmtCtx, ist *Stream) (int, int) {
 func main() {
 	var srcFileName, dstFileName string
 	var stMap map[int]int = make(map[int]int, 0)
-	var lastDelta int
+	var lastDelta int64
 
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Ltime)
 


### PR DESCRIPTION
Hi,

I noticed one of your examples were broken by 993164f3d726fd1ee1da63ae7e714301b7815136 so I've updated it to compile.

Regards,
Stacey Ell