### PR TITLE
Bugfixes

### DIFF
--- a/codecCtx.go
+++ b/codecCtx.go
@@ -282,7 +282,7 @@ func (this *CodecCtx) Channels() int {
 }
 
 func (this *CodecCtx) SetBitRate(val int) *CodecCtx {
-	this.avCodecCtx.bit_rate = C.int(val)
+	this.avCodecCtx.bit_rate = C.int64_t(val)
 	return this
 }
 

--- a/packet.go
+++ b/packet.go
@@ -190,7 +190,7 @@ func (this *Packet) Duration() int {
 }
 
 func (this *Packet) SetDuration(duration int) {
-	this.avPacket.duration = C.int(duration)
+	this.avPacket.duration = C.int64_t(duration)
 }
 
 func (this *Packet) StreamIndex() int {

--- a/packet.go
+++ b/packet.go
@@ -228,5 +228,5 @@ func (this *Packet) SetStreamIndex(val int) *Packet {
 }
 
 func (this *Packet) Free() {
-	C.av_free_packet(&this.avPacket)
+	C.av_packet_unref(&this.avPacket)
 }


### PR DESCRIPTION
This pull resolves the following compile errors/warnings:

    packet.go:61:2: warning: 'av_free_packet' is deprecated [-Wdeprecated-declarations]
    /usr/local/ffmpeg/include/libavcodec/avcodec.h:4040:6: note: 'av_free_packet' has been explicitly marked deprecated here

    codecCtx.go:285: cannot use C.int(val) (type C.int) as type C.int64_t in assignment
    packet.go:193: cannot use C.int(duration) (type C.int) as type C.int64_t in assignment
