### PR TITLE
Fix go 1.6 "cgo argument has Go pointer to Go pointer" error

### DIFF
--- a/codecCtx.go
+++ b/codecCtx.go
@@ -60,7 +60,7 @@ static int select_channel_layout(AVCodec *codec) {
 }
 
 static void call_av_freep(AVCodecContext *out){
-	return av_freep(&out);
+    return av_freep(&out);
 }
 */
 import "C"
@@ -207,7 +207,7 @@ func (this *CodecCtx) Free() {
 
 func (this *CodecCtx) CloseAndRelease() {
 	this.Close()
-	C.call_av_freep(this.avCodecCtx)
+	C.call_av_freep(unsafe.Pointer(this.avCodecCtx))
 }
 
 // @todo

--- a/codecCtx.go
+++ b/codecCtx.go
@@ -59,6 +59,9 @@ static int select_channel_layout(AVCodec *codec) {
     return best_ch_layout;
 }
 
+static void call_av_freep(AVCodecContext *out){
+	return av_freep(&out);
+}
 */
 import "C"
 
@@ -204,7 +207,7 @@ func (this *CodecCtx) Free() {
 
 func (this *CodecCtx) CloseAndRelease() {
 	this.Close()
-	C.av_freep(unsafe.Pointer(&this.avCodecCtx))
+	C.call_av_freep(this.avCodecCtx)
 }
 
 // @todo


### PR DESCRIPTION
In 1.6, new rules are introduced for passing pointers between C and Go, you can read more about it here https://github.com/golang/go/issues/12416. The current test suite fails under the new rules:

```bash
$ go test
2016/03/13 01:21:32 CodecCtx is successfully created and opened.
--- FAIL: TestCodecCtx (0.00s)
panic: runtime error: cgo argument has Go pointer to Go pointer [recovered]
	panic: runtime error: cgo argument has Go pointer to Go pointer
```
The pull request fixes that.