### PR TITLE
Expose av_write_frame() and avio_flush()

### DIFF
--- a/avio.go
+++ b/avio.go
@@ -102,6 +102,10 @@ func (this *AVIOContext) Free() {
 	C.av_free(unsafe.Pointer(this.avAVIOContext))
 }
 
+func (this *AVIOContext) Flush() {
+	C.avio_flush(unsafe.Pointer(this.avAVIOContext))
+}
+
 //export readCallBack
 func readCallBack(opaque unsafe.Pointer, buf *C.uint8_t, buf_size C.int) C.int {
 	handlers, found := handlersMap[uintptr(opaque)]

--- a/format.go
+++ b/format.go
@@ -283,6 +283,14 @@ func (this *FmtCtx) WritePacket(p *Packet) error {
 	return nil
 }
 
+func (this *FmtCtx) WritePacketNoBuffer(p *Packet) error {
+	if averr := C.av_write_frame(this.avCtx, &p.avPacket); averr < 0 {
+		return errors.New(fmt.Sprintf("Unable to write packet to '%s': %s", this.Filename, AvError(int(averr))))
+	}
+
+	return nil
+}
+
 func (this *FmtCtx) SetOformat(ofmt *OutputFmt) error {
 	if ofmt == nil {
 		return errors.New("'ofmt' is not initialized.")


### PR DESCRIPTION
Exposes avio functions to write to output context without the default buffer for DTS ordering.

See doc:
https://www.ffmpeg.org/doxygen/3.1/group__lavf__encoding.html#gaa85cc1774f18f306cd20a40fc50d0b36
