### PR TITLE
Linking Issues with gmf master with ffmpeg tag n3.3.2

### DIFF
--- a/format.go
+++ b/format.go
@@ -3,7 +3,7 @@ package gmf
 
 /*
 
-#cgo pkg-config: libavformat libavdevice
+#cgo pkg-config: libavformat libavdevice libavfilter
 
 #include <stdlib.h>
 #include "libavformat/avformat.h"


### PR DESCRIPTION
[kishore-4306@localhost ~]$ go get github.com/3d0c/gmf
&#35 github.com/3d0c/gmf
cgo-gcc-prolog: In function ‘_cgo_e1ea90aebbbc_Cfunc_avcodec_encode_audio2’:
cgo-gcc-prolog:197:2: warning: ‘avcodec_encode_audio2’ is deprecated (declared at /usr/local/ffmpeg/include/libavcodec/avcodec.h:5377) [-Wdeprecated-declarations]
cgo-gcc-prolog: In function ‘_cgo_e1ea90aebbbc_Cfunc_avcodec_encode_video2’:
cgo-gcc-prolog:218:2: warning: ‘avcodec_encode_video2’ is deprecated (declared at /usr/local/ffmpeg/include/libavcodec/avcodec.h:5416) [-Wdeprecated-declarations]
&#35github.com/3d0c/gmf
cgo-gcc-prolog: In function ‘_cgo_e1ea90aebbbc_Cfunc_avcodec_decode_audio4’:
cgo-gcc-prolog:87:2: warning: ‘avcodec_decode_audio4’ is deprecated (declared at /usr/local/ffmpeg/include/libavcodec/avcodec.h:4852) [-Wdeprecated-declarations]
cgo-gcc-prolog: In function ‘_cgo_e1ea90aebbbc_Cfunc_avcodec_decode_video2’:
cgo-gcc-prolog:108:2: warning: ‘avcodec_decode_video2’ is deprecated (declared at /usr/local/ffmpeg/include/libavcodec/avcodec.h:4901) [-Wdeprecated-declarations]
&#35github.com/3d0c/gmf
cgo-gcc-prolog: In function ‘_cgo_e1ea90aebbbc_Cfunc_avcodec_copy_context’:
cgo-gcc-prolog:42:2: warning: ‘avcodec_copy_context’ is deprecated (declared at /usr/local/ffmpeg/include/libavcodec/avcodec.h:4326) [-Wdeprecated-declarations]
&#35 github.com/3d0c/gmf
/usr/bin/ld: warning: libavfilter.so.6, needed by /usr/local/ffmpeg/lib/libavdevice.so, not found (try using -rpath or -rpath-link)
/usr/local/ffmpeg/lib/libavdevice.so: undefined reference to `av_buffersink_get_channel_layout@LIBAVFILTER_6'
/usr/local/ffmpeg/lib/libavdevice.so: undefined reference to `avfilter_pad_get_type@LIBAVFILTER_6'
/usr/local/ffmpeg/lib/libavdevice.so: undefined reference to `avfilter_graph_alloc@LIBAVFILTER_6'
/usr/local/ffmpeg/lib/libavdevice.so: undefined reference to `av_buffersink_get_sample_aspect_ratio@LIBAVFILTER_6'
/usr/local/ffmpeg/lib/libavdevice.so: undefined reference to `av_buffersink_get_w@LIBAVFILTER_6'
/usr/local/ffmpeg/lib/libavdevice.so: undefined reference to `av_buffersink_get_channels@LIBAVFILTER_6'
/usr/local/ffmpeg/lib/libavdevice.so: undefined reference to `avfilter_graph_parse_ptr@LIBAVFILTER_6'
/usr/local/ffmpeg/lib/libavdevice.so: undefined reference to `avfilter_graph_create_filter@LIBAVFILTER_6'
/usr/local/ffmpeg/lib/libavdevice.so: undefined reference to `av_buffersink_get_format@LIBAVFILTER_6'
/usr/local/ffmpeg/lib/libavdevice.so: undefined reference to `avfilter_graph_free@LIBAVFILTER_6'
/usr/local/ffmpeg/lib/libavdevice.so: undefined reference to `avfilter_get_by_name@LIBAVFILTER_6'
/usr/local/ffmpeg/lib/libavdevice.so: undefined reference to `av_buffersink_get_frame_flags@LIBAVFILTER_6'
/usr/local/ffmpeg/lib/libavdevice.so: undefined reference to `av_buffersink_get_type@LIBAVFILTER_6'
/usr/local/ffmpeg/lib/libavdevice.so: undefined reference to `avfilter_inout_free@LIBAVFILTER_6'
/usr/local/ffmpeg/lib/libavdevice.so: undefined reference to `av_buffersink_get_h@LIBAVFILTER_6'
/usr/local/ffmpeg/lib/libavdevice.so: undefined reference to `avfilter_register_all@LIBAVFILTER_6'
/usr/local/ffmpeg/lib/libavdevice.so: undefined reference to `avfilter_graph_dump@LIBAVFILTER_6'
/usr/local/ffmpeg/lib/libavdevice.so: undefined reference to `avfilter_graph_config@LIBAVFILTER_6'
/usr/local/ffmpeg/lib/libavdevice.so: undefined reference to `avfilter_link@LIBAVFILTER_6'
/usr/local/ffmpeg/lib/libavdevice.so: undefined reference to `av_buffersink_get_time_base@LIBAVFILTER_6'
/usr/local/ffmpeg/lib/libavdevice.so: undefined reference to `av_buffersink_get_sample_rate@LIBAVFILTER_6'
collect2: error: ld returned 1 exit status
[kishore-4306@localhost ~]$ 
