### PR TITLE
Fix macro names.

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -195,5 +195,5 @@ func (this *Codec) Type() int {
 }
 
 func (this *Codec) IsExperimental() bool {
-	return bool((this.avCodec.capabilities & C.CODEC_CAP_EXPERIMENTAL) != 0)
+	return bool((this.avCodec.capabilities & C.AV_CODEC_CAP_EXPERIMENTAL) != 0)
 }

--- a/codecCtx.go
+++ b/codecCtx.go
@@ -90,7 +90,7 @@ var (
 	AV_CODEC_ID_GIF        int = C.AV_CODEC_ID_GIF
 	AV_CODEC_ID_RAWVIDEO   int = C.AV_CODEC_ID_RAWVIDEO
 
-	CODEC_FLAG_GLOBAL_HEADER int = C.CODEC_FLAG_GLOBAL_HEADER
+	CODEC_FLAG_GLOBAL_HEADER int = C.AV_CODEC_FLAG_GLOBAL_HEADER
 	FF_MB_DECISION_SIMPLE    int = C.FF_MB_DECISION_SIMPLE
 	FF_MB_DECISION_BITS      int = C.FF_MB_DECISION_BITS
 	FF_MB_DECISION_RD        int = C.FF_MB_DECISION_RD
@@ -156,7 +156,7 @@ func (this *CodecCtx) CopyExtra(ist *Stream) *CodecCtx {
 
 	codec.field_order = icodec.field_order
 
-	codec.extradata = (*_Ctype_uint8_t)(C.av_mallocz((_Ctype_size_t)((C.uint64_t)(icodec.extradata_size) + C.FF_INPUT_BUFFER_PADDING_SIZE)))
+	codec.extradata = (*_Ctype_uint8_t)(C.av_mallocz((_Ctype_size_t)((C.uint64_t)(icodec.extradata_size) + C.AV_INPUT_BUFFER_PADDING_SIZE)))
 
 	C.memcpy(unsafe.Pointer(codec.extradata), unsafe.Pointer(icodec.extradata), (_Ctype_size_t)(icodec.extradata_size))
 	codec.extradata_size = icodec.extradata_size

--- a/stream.go
+++ b/stream.go
@@ -32,7 +32,7 @@ func (s *Stream) DumpContexCodec(codec *CodecCtx) {
 }
 
 func (s *Stream) SetCodecFlags() {
-	s.avStream.codec.flags |= C.CODEC_FLAG_GLOBAL_HEADER
+	s.avStream.codec.flags |= C.AV_CODEC_FLAG_GLOBAL_HEADER
 }
 
 func (s *Stream) CodecCtx() *CodecCtx {


### PR DESCRIPTION
Here is ffmpeg-4.0. Not sure version related. But here work fine with changed names.

Another, looks like the code is not gofmted. It's better if gofmt the code.
