### PR TITLE
[video-to-jpeg-avio] Broken example app

### DIFF
--- a/examples/video-to-jpeg-avio.go
+++ b/examples/video-to-jpeg-avio.go
@@ -49,7 +49,7 @@ func customReader() ([]byte, int) {
 }
 
 func writeFile(b []byte) {
-	name := "./tmp-img/" + strconv.Itoa(seq) + ".jpg"
+	name := "tmp-img/" + strconv.Itoa(seq) + ".jpg"
 
 	fp, err := os.Create(name)
 	if err != nil {


### PR DESCRIPTION
Wrong path reference fix: `./tmp-img/` ----> `tmp-img/`
Current path reference ended up `no such file`