### PR TITLE
Fixed errors propagated in encoding.go

### DIFF
--- a/examples/encoding.go
+++ b/examples/encoding.go
@@ -23,13 +23,13 @@ func main() {
 
 	videoEncCtx := NewCodecCtx(codec)
 	if videoEncCtx == nil {
-		fatal(err)
+		fatal("failed to create a new codec context")
 	}
 	defer Release(videoEncCtx)
 
 	outputCtx, err := NewOutputCtx(outputfilename)
 	if err != nil {
-		fatal(err)
+		fatal("failed to create a new output context")
 	}
 
 	videoEncCtx.


### PR DESCRIPTION
The errors were propagated from previous calls when creating contexts probably due to copy/paste mistakes.