### PR TITLE
Update encoding.go to wrap error messages

### DIFF
--- a/examples/encoding.go
+++ b/examples/encoding.go
@@ -23,13 +23,13 @@ func main() {
 
 	videoEncCtx := NewCodecCtx(codec)
 	if videoEncCtx == nil {
-		fatal("failed to create a new codec context")
+		fatal(errors.New("failed to create a new codec context"))
 	}
 	defer Release(videoEncCtx)
 
 	outputCtx, err := NewOutputCtx(outputfilename)
 	if err != nil {
-		fatal("failed to create a new output context")
+		fatal(errors.New("failed to create a new output context"))
 	}
 
 	videoEncCtx.


### PR DESCRIPTION
`fatal(.)` requires error interface, hence the error messages need to be wrapped with `errors.New(.)`.