### PR TITLE
FIx video-to-image examples not working with H264 videos

### DIFF
--- a/examples/video-to-image.go
+++ b/examples/video-to-image.go
@@ -104,10 +104,16 @@ func main() {
 			continue
 		}
 
+	decode:
 		frame, err := packet.Frames(codecCtx)
 		if err != nil {
+			// Retry if EAGAIN
+			if err.Error() == "Resource temporarily unavailable" {
+				goto decode
+			}
 			log.Fatal(err)
 		}
+
 		swsCtx.Scale(frame, dstFrame)
 
 		p, err := dstFrame.Encode(cc)

--- a/examples/video-to-jpeg-avio.go
+++ b/examples/video-to-jpeg-avio.go
@@ -141,8 +141,13 @@ func main() {
 
 		fmt.Println(p)
 
+	decode:
 		frame, err := p.Frames(ist.CodecCtx())
 		if err != nil {
+			// Retry if EAGAIN
+			if err.Error() == "Resource temporarily unavailable" {
+				goto decode
+			}
 			log.Fatal(err)
 		}
 

--- a/examples/video-to-jpeg-p.go
+++ b/examples/video-to-jpeg-p.go
@@ -50,7 +50,7 @@ func writeFile(b []byte) {
 	}
 }
 
-func encodeWorker(data chan *Frame, wg *sync.WaitGroup, srcCtx *CodecCtx) {
+func encodeWorker(data chan *Frame, wg *sync.WaitGroup, srcCtx *CodecCtx, timeBase AVR) {
 	defer wg.Done()
 	log.Println("worker started")
 	codec, err := FindEncoder(AV_CODEC_ID_JPEG2000)
@@ -63,7 +63,7 @@ func encodeWorker(data chan *Frame, wg *sync.WaitGroup, srcCtx *CodecCtx) {
 
 	w, h := srcCtx.Width(), srcCtx.Height()
 
-	cc.SetPixFmt(AV_PIX_FMT_RGB24).SetWidth(w).SetHeight(h)
+	cc.SetPixFmt(AV_PIX_FMT_RGB24).SetWidth(w).SetHeight(h).SetTimeBase(timeBase)
 
 	if codec.IsExperimental() {
 		cc.SetStrictCompliance(FF_COMPLIANCE_EXPERIMENTAL)
@@ -135,7 +135,7 @@ func main() {
 
 	for i := 0; i < *wnum; i++ {
 		wg.Add(1)
-		go encodeWorker(dataChan, wg, srcVideoStream.CodecCtx())
+		go encodeWorker(dataChan, wg, srcVideoStream.CodecCtx(), srcVideoStream.TimeBase().AVR())
 	}
 
 	for packet := range inputCtx.GetNewPackets() {

--- a/examples/video-to-jpeg-p.go
+++ b/examples/video-to-jpeg-p.go
@@ -146,8 +146,13 @@ func main() {
 
 		ist := assert(inputCtx.GetStream(packet.StreamIndex())).(*Stream)
 
+	decode:
 		frame, err := packet.Frames(ist.CodecCtx())
 		if err != nil {
+			// Retry if EAGAIN
+			if err.Error() == "Resource temporarily unavailable" {
+				goto decode
+			}
 			log.Fatal(err)
 		}
 

--- a/examples/video-to-jpeg-p.go
+++ b/examples/video-to-jpeg-p.go
@@ -112,7 +112,11 @@ func main() {
 	os.Mkdir("./tmp", 0755)
 
 	wnum := flag.Int("wnum", 10, "number of workers")
-	srcFileName := flag.String("input", "tests-sample.mp4", "input file")
+
+	srcFileName := "tests-sample.mp4"
+	if len(os.Args) > 1 {
+		srcFileName = os.Args[1]
+	}
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stdout, "Usage: %s [OPTIONS]\n", os.Args[0])
@@ -121,7 +125,7 @@ func main() {
 
 	flag.Parse()
 
-	inputCtx := assert(NewInputCtx(*srcFileName)).(*FmtCtx)
+	inputCtx := assert(NewInputCtx(srcFileName)).(*FmtCtx)
 	defer inputCtx.CloseInputAndRelease()
 
 	srcVideoStream, err := inputCtx.GetBestStream(AVMEDIA_TYPE_VIDEO)

--- a/examples/video-to-mjpeg.go
+++ b/examples/video-to-mjpeg.go
@@ -91,8 +91,13 @@ func main() {
 		}
 		ist := assert(inputCtx.GetStream(packet.StreamIndex())).(*Stream)
 
+	decode:
 		frame, err := packet.Frames(ist.CodecCtx())
 		if err != nil {
+			// Retry if EAGAIN
+			if err.Error() == "Resource temporarily unavailable" {
+				goto decode
+			}
 			log.Fatal(err)
 		}
 

--- a/examples/video-to-png.go
+++ b/examples/video-to-png.go
@@ -105,8 +105,13 @@ func main() {
 		}
 		ist := assert(inputCtx.GetStream(packet.StreamIndex())).(*Stream)
 
+	decode:
 		frame, err := packet.Frames(ist.CodecCtx())
 		if err != nil {
+			// Retry if EAGAIN
+			if err.Error() == "Resource temporarily unavailable" {
+				goto decode
+			}
 			log.Fatal(err)
 		}
 


### PR DESCRIPTION
I tried `video-to-xxx.go` examples with H264/MP4 videos then I encountered several errors.
This PR includes fixes to work with H264 videos.

I used [my own VJ loops](https://drive.google.com/open?id=1fSohDCgoR720QqDWzBRE-ikFMxBHt1z0) and other H264 videos downloaded from [beeple](https://www.beeple-crap.com/vjloops).

##  Retry decoding if err is EAGAIN 034ff4f

When I run `video-to-image.go` with H264 file,  it threw an error: `Resource temporarily unavailable` on [`packet.Frames()`](https://github.com/3d0c/gmf/blob/master/examples/video-to-image.go#L107).
The error message came from ffmpeg's `EAGAIN`, it means we should retry `avcodec_receive_frame` until it succeeds.

- https://github.com/FFmpeg/FFmpeg/blob/master/libavutil/error.c#L66
- https://ffmpeg.org/doxygen/4.1/group__lavc__decoding.html#ga11e6542c4e66d3028668788a1a74217c

I added retry code to video-to-*.go files.
It uses `goto` for simplicity, but if you don't like it I'll rewrite them with `for` loop.


## Set encoder's timebase in video-to-jpeg-p.go aebce39

`go run examples/video-to-jpeg-p.go foo.mp4` throws an error: 
`[jpeg2000 @ 0x880dc00] The encoder timebase is not set.`

I set the codec context's timebase to `srcVideoStream.TimeBase.AVR()`.


## Scale frames in video-to-mjpeg.go a557b34

`go run examples/video-to-mjpeg.go foo.mp4` throws an error: 
`[mjpeg @ 0xc001200] Invalid pts (0) <= last (0)`

I noticed `video-to-mjpeg.go` was not converting frames with sws, so I added `swsCtx.Scale(frame, dstFrame)` before encoding.
It works, but I'm not sure this is the right decision... 😅 


## Use CLI args instead of flags, like other examples 62f2394

`video-to-jpeg-p.go` takes input video from CLI flag while other examples takes input from CLI args.
It's confusing, so I fixed it.

---

BTW gmf is the best repo for video editing in go, thanks @3d0c ! 💪 