### PR TITLE
Added a method to get Frame.avFrame

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -228,6 +228,10 @@ func (f *Frame) IsNil() bool {
 	return false
 }
 
+func (f *Frame) GetRawFrame() *C.struct_AVFrame {
+	return f.avFrame
+}
+
 func (f *Frame) Time(timebase AVRational) int {
 	return int(float64(timebase.AVR().Num) / float64(timebase.AVR().Den) * float64(f.Pts()))
 }


### PR DESCRIPTION
Hi  @3d0c, 
I needed to work with raw AVFrame, so I added `Frame.GetRawFrame()` which returns `*AVFrame`, raw pointer to C struct.

It might be useful to work with FFMpeg APIs outside of gmf.

For example, I needed to flip frames vertically while encoding to show frames in OpenGL window.
In OpenGL the origin is located on left-bottom corner so basically we have to invert images.

We can achieve this with filters, but I wanted to do it using `sws_scale` for performance sake.
If we can get raw `*AVFrame` it can be done like this:

```go
/*
#include "libavutil/frame.h"

// Modify frame->data and frame->linesize so that images will flip vertically on sws_scale
// ref. http://www.ffmpeg-archive.org/Flip-in-sws-scale-td939665.html
void flip_y(uint8_t** data, int* linesize, int width, int height) {
	for (int i = 0; i < AV_NUM_DATA_POINTERS; i++) {
		int h = (int)(height * ((float)linesize[i] / width));
		data[i] += linesize[i] * (h - 1);
		linesize[i] = -linesize[i];
	}
}
*/
import "C"

func main() {
	...

	// Get raw pointer to AVFrame
	avFrame := (*C.struct_AVFrame)(unsafe.Pointer(frame.GetRawFrame()))

	// Do the flip
	C.flip_y(
		(**C.uint8_t)(unsafe.Pointer(&avFrame.data)),
		(*_Ctype_int)(unsafe.Pointer(&avFrame.linesize)),
		C.int(frame.Width()),
		C.int(frame.Height()),
	)

	// Call sws_scale as usual
	v.swsCtx.Scale(frame, v.dstFrame)

	...
}
```