### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/avio.go
+++ b/avio.go
@@ -61,7 +61,7 @@ type AVIOContext struct {
 	CgoMemoryManage
 }
 
-// AVIOContext constructor. Use it only if You need custom IO behaviour!
+// NewAVIOContext constructor. Use it only if You need custom IO behaviour!
 func NewAVIOContext(ctx *FmtCtx, handlers *AVIOHandlers, size ...int) (*AVIOContext, error) {
 	this := &AVIOContext{}
 

--- a/frame.go
+++ b/frame.go
@@ -78,7 +78,7 @@ func (f *Frame) SetPts(val int64) {
 	f.avFrame.pts = (_Ctype_int64_t)(val)
 }
 
-// AVPixelFormat for video frames, AVSampleFormat for audio
+// Format for video frames, AVSampleFormat for audio
 func (f *Frame) Format() int {
 	return int(f.avFrame.format)
 }


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._