### PR TITLE
Support for avformat_open_input options

### DIFF
--- a/format_go112.go
+++ b/format_go112.go
@@ -244,7 +244,7 @@ func (this *FmtCtx) OpenInput(filename string) error {
 	//Create an empty Option object to pass to the open input
 	inputOptionsDict := NewDict([]Pair{})
 	inputOption := &Option{Key: "input_options", Val: inputOptionsDict}
-	if err := this.OpenInputWithOption(filename, nil); err != nil {
+	if err := this.OpenInputWithOption(filename, inputOption); err != nil {
 		return err
 	}
 

--- a/format_go112.go
+++ b/format_go112.go
@@ -218,7 +218,7 @@ func (this *FmtCtx) SetOptions(options []*Option) {
 
 func (this *FmtCtx) OpenInputWithOption(filename string, inputOptions *Option) error {
 	var (
-		cfilename *_Ctype_char
+		cfilename *C.char
 		options   *C.struct_AVDictionary = inputOptions.Val.(*Dict).avDict
 	)
 
@@ -241,6 +241,9 @@ func (this *FmtCtx) OpenInputWithOption(filename string, inputOptions *Option) e
 }
 
 func (this *FmtCtx) OpenInput(filename string) error {
+	//Create an empty Option object to pass to the open input
+	inputOptionsDict := NewDict([]Pair{})
+	inputOption := &Option{Key: "input_options", Val: inputOptionsDict}
 	if err := this.OpenInputWithOption(filename, nil); err != nil {
 		return err
 	}

--- a/format_go112.go
+++ b/format_go112.go
@@ -216,10 +216,10 @@ func (this *FmtCtx) SetOptions(options []*Option) {
 	}
 }
 
-func (this *FmtCtx) OpenInput(filename string) error {
+func (this *FmtCtx) OpenInputWithOption(filename string, inputOptions *Option) error {
 	var (
-		cfilename *C.char
-		options   *C.struct_AVDictionary = nil
+		cfilename *_Ctype_char
+		options   *C.struct_AVDictionary = inputOptions.Val.(*Dict).avDict
 	)
 
 	if filename == "" {
@@ -235,6 +235,14 @@ func (this *FmtCtx) OpenInput(filename string) error {
 
 	if averr := C.avformat_find_stream_info(this.avCtx, nil); averr < 0 {
 		return errors.New(fmt.Sprintf("Unable to find stream info: %s", AvError(int(averr))))
+	}
+
+	return nil
+}
+
+func (this *FmtCtx) OpenInput(filename string) error {
+	if err := this.OpenInputWithOption(filename, nil); err != nil {
+		return err
 	}
 
 	return nil

--- a/format_go16.go
+++ b/format_go16.go
@@ -216,10 +216,10 @@ func (this *FmtCtx) SetOptions(options []*Option) {
 	}
 }
 
-func (this *FmtCtx) OpenInput(filename string) error {
+func (this *FmtCtx) OpenInputWithOption(filename string, inputOptions *Option) error {
 	var (
 		cfilename *_Ctype_char
-		options   *C.struct_AVDictionary = nil
+		options   *C.struct_AVDictionary = inputOptions.Val.(*Dict).avDict
 	)
 
 	if filename == "" {
@@ -235,6 +235,14 @@ func (this *FmtCtx) OpenInput(filename string) error {
 
 	if averr := C.avformat_find_stream_info(this.avCtx, nil); averr < 0 {
 		return errors.New(fmt.Sprintf("Unable to find stream info: %s", AvError(int(averr))))
+	}
+
+	return nil
+}
+
+func (this *FmtCtx) OpenInput(filename string) error {
+	if err := this.OpenInputWithOption(filename, nil); err != nil {
+		return err
 	}
 
 	return nil

--- a/format_go16.go
+++ b/format_go16.go
@@ -241,7 +241,10 @@ func (this *FmtCtx) OpenInputWithOption(filename string, inputOptions *Option) e
 }
 
 func (this *FmtCtx) OpenInput(filename string) error {
-	if err := this.OpenInputWithOption(filename, nil); err != nil {
+	//Create an empty Option object to pass to the open input
+	inputOptionsDict := NewDict([]Pair{})
+	inputOption := &Option{Key: "input_options", Val: inputOptionsDict}
+	if err := this.OpenInputWithOption(filename, inputOption); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Previous to this commit, no options could be given to the
FmtCtx.OpenInput function. For input formats like video4linux2, that
means options to specify input format (rawvideo, h264, etc.) or
framerate were impossible.

This commit introduces a new FmtCtx.OpenInputWithOption function that
takes a Option parameter. To maintain backwards compatibility, the
OpenInput function now just calls the OpenInputWithOption function, but
passes a nil value for the Option parameter.

Example usage:
```
  inputOptionsDict := gmf.NewDict([]gmf.Pair{
          {"white_balance_auto_preset","4"},
          {"input_format", "h264"},
  })

  inputCtx := gmf.NewCtx()
  inputCtx.SetInputFormat("video4linux2")

  inputOption := &gmf.Option{Key: "video4linux_input_options", Val: inputOptionsDict}

  err := inputCtx.OpenInputWithOption("/dev/video0", inputOption)
```