### PR TITLE
add fn for Packet and CodecCtx

### DIFF
--- a/codecCtx_go112.go
+++ b/codecCtx_go112.go
@@ -237,6 +237,16 @@ func (cc *CodecCtx) CopyExtra(ist *Stream) *CodecCtx {
 	return cc
 }
 
+func (cc *CodecCtx) SetExtradata(extradata []byte) *CodecCtx {
+	codec := cc.avCodecCtx
+	codec.extradata_size = C.int(len(extradata))
+	codec.extradata = (*C.uint8_t)(C.av_mallocz((C.size_t)((C.uint64_t)(len(extradata)) + C.AV_INPUT_BUFFER_PADDING_SIZE)))
+	tmp := unsafe.Pointer(C.CBytes(extradata))
+	C.memcpy(unsafe.Pointer(codec.extradata), tmp, (C.size_t)(codec.extradata_size))
+	C.free(tmp)
+	return cc
+}
+
 func (cc *CodecCtx) Open(dict *Dict) error {
 	if cc.IsOpen() {
 		return nil

--- a/packet_go112.go
+++ b/packet_go112.go
@@ -41,16 +41,18 @@ func (p *Packet) Pts() int64 {
 	return int64(p.avPacket.pts)
 }
 
-func (p *Packet) SetPts(pts int64) {
+func (p *Packet) SetPts(pts int64) *Packet {
 	p.avPacket.pts = C.int64_t(pts)
+	return p
 }
 
 func (p *Packet) Dts() int64 {
 	return int64(p.avPacket.dts)
 }
 
-func (p *Packet) SetDts(val int64) {
+func (p *Packet) SetDts(val int64) *Packet {
 	p.avPacket.dts = C.int64_t(val)
+	return p
 }
 
 func (p *Packet) Flags() int {
@@ -61,8 +63,9 @@ func (p *Packet) Duration() int64 {
 	return int64(p.avPacket.duration)
 }
 
-func (p *Packet) SetDuration(duration int64) {
+func (p *Packet) SetDuration(duration int64) *Packet {
 	p.avPacket.duration = C.int64_t(duration)
+	return p
 }
 
 func (p *Packet) StreamIndex() int {
@@ -79,6 +82,15 @@ func (p *Packet) Pos() int64 {
 
 func (p *Packet) Data() []byte {
 	return C.GoBytes(unsafe.Pointer(p.avPacket.data), C.int(p.avPacket.size))
+}
+
+func (p *Packet) SetData(data []byte) *Packet {
+	p.avPacket.size = C.int(len(data))
+	p.avPacket.data = (*C.uint8_t)(C.av_mallocz((C.size_t)(len(data))))
+	tmp := unsafe.Pointer(C.CBytes(data))
+	C.memcpy(unsafe.Pointer(p.avPacket.data), unsafe.Pointer(C.CBytes(data)), (C.size_t)(p.avPacket.size))
+	C.free(tmp)
+	return p
 }
 
 func (p *Packet) Clone() *Packet {

--- a/packet_go112.go
+++ b/packet_go112.go
@@ -88,7 +88,7 @@ func (p *Packet) SetData(data []byte) *Packet {
 	p.avPacket.size = C.int(len(data))
 	p.avPacket.data = (*C.uint8_t)(C.av_mallocz((C.size_t)(len(data))))
 	tmp := unsafe.Pointer(C.CBytes(data))
-	C.memcpy(unsafe.Pointer(p.avPacket.data), unsafe.Pointer(C.CBytes(data)), (C.size_t)(p.avPacket.size))
+	C.memcpy(unsafe.Pointer(p.avPacket.data), tmp, (C.size_t)(p.avPacket.size))
 	C.free(tmp)
 	return p
 }


### PR DESCRIPTION
h264 raw stream to rtmp, so i need SetExtradata to set sps and pps, alse need SetData to set h264 raw data to packet. 

We must have extradata to generate AVCDecoderConfigurationRecord.
```go
//sps_pps = []byte{ 0x00, 0x00, 0x01, 0x67, 0x4d, 0x00, 0x1f, 0x9d, 0xa8, 0x14, 0x01, 0x6e, 0x9b, 0x80, 0x80, 0x80, 0x81, 0x00, 0x00, 0x00, 0x01, 0x68, 0xee, 0x3c, 0x80 }
	extradata := pkt.PacketBuffer[:index]
	cc.SetHeight(int(pkt.Height)).
		SetWidth(int(pkt.Width)).
		SetFrameRate(gmf.AVR{
			Num: int(pkt.FrameRate),
			Den: 1,
		}).
		SetPixFmt(gmf.AV_PIX_FMT_YUV420P).
		SetExtradata(extradata)
```