### PR TITLE
protect avio handler map with mutex

### DIFF
--- a/avio_go16.go
+++ b/avio_go16.go
@@ -55,6 +55,7 @@ type AVIOHandlers struct {
 // Global map of AVIOHandlers
 // one handlers struct per format context. Using ctx.avCtx pointer address as a key.
 var handlersMap map[uintptr]*AVIOHandlers
+var handlersMapMu sync.Mutex
 
 type AVIOContext struct {
 	avAVIOContext *_Ctype_AVIOContext
@@ -84,11 +85,13 @@ func NewAVIOContext(ctx *FmtCtx, handlers *AVIOHandlers, size ...int) (*AVIOCont
 	var ptrRead, ptrWrite, ptrSeek *[0]byte = nil, nil, nil
 
 	if handlers != nil {
+		handlersMapMu.Lock()
 		if handlersMap == nil {
 			handlersMap = make(map[uintptr]*AVIOHandlers)
 		}
 
 		handlersMap[uintptr(unsafe.Pointer(ctx.avCtx))] = handlers
+		handlersMapMu.Unlock()
 		this.handlerKey = uintptr(unsafe.Pointer(ctx.avCtx))
 	}
 
@@ -123,7 +126,9 @@ func NewAVIOContext(ctx *FmtCtx, handlers *AVIOHandlers, size ...int) (*AVIOCont
 }
 
 func (this *AVIOContext) Free() {
+	handlersMapMu.Lock()
 	delete(handlersMap, this.handlerKey)
+	handlersMapMu.Unlock()
 	C.av_free(unsafe.Pointer(this.avAVIOContext.buffer))
 	C.av_free(unsafe.Pointer(this.avAVIOContext))
 }
@@ -134,7 +139,9 @@ func (this *AVIOContext) Flush() {
 
 //export readCallBack
 func readCallBack(opaque unsafe.Pointer, buf *C.uint8_t, buf_size C.int) C.int {
+	handlersMapMu.Lock()
 	handlers, found := handlersMap[uintptr(opaque)]
+	handlersMapMu.Unlock()
 	if !found {
 		panic(fmt.Sprintf("No handlers instance found, according pointer: %v", opaque))
 	}
@@ -153,7 +160,9 @@ func readCallBack(opaque unsafe.Pointer, buf *C.uint8_t, buf_size C.int) C.int {
 
 //export writeCallBack
 func writeCallBack(opaque unsafe.Pointer, buf *C.uint8_t, buf_size C.int) C.int {
+	handlersMapMu.Lock()
 	handlers, found := handlersMap[uintptr(opaque)]
+	handlersMapMu.Unlock()
 	if !found {
 		panic(fmt.Sprintf("No handlers instance found, according pointer: %v", opaque))
 	}
@@ -167,7 +176,9 @@ func writeCallBack(opaque unsafe.Pointer, buf *C.uint8_t, buf_size C.int) C.int 
 
 //export seekCallBack
 func seekCallBack(opaque unsafe.Pointer, offset C.int64_t, whence C.int) C.int64_t {
+	handlersMapMu.Lock()
 	handlers, found := handlersMap[uintptr(opaque)]
+	handlersMapMu.Unlock()
 	if !found {
 		panic(fmt.Sprintf("No handlers instance found, according pointer: %v", opaque))
 	}


### PR DESCRIPTION
using avio from multiple goroutines can cause runtime panics because of unsafe access to handlersMap.