### PR TITLE
fixed FFMPEG 5.1 issues

### DIFF
--- a/format_go112.go
+++ b/format_go112.go
@@ -285,11 +285,11 @@ func (ctx *FmtCtx) IsGlobalHeader() bool {
 }
 
 func (ctx *FmtCtx) WriteHeader() error {
-	cfilename := &(ctx.avCtx.filename[0])
+	cfilename := &(ctx.avCtx.url)
 
 	// If NOFILE flag isn't set and we don't use custom IO, open it
 	if !ctx.IsNoFile() && !ctx.customPb {
-		if averr := C.avio_open(&ctx.avCtx.pb, cfilename, C.AVIO_FLAG_WRITE); averr < 0 {
+		if averr := C.avio_open(&ctx.avCtx.pb, *cfilename, C.AVIO_FLAG_WRITE); averr < 0 {
 			return errors.New(fmt.Sprintf("Unable to open '%s': %s", ctx.Filename, AvError(int(averr))))
 		}
 	}
@@ -331,9 +331,9 @@ func (ctx *FmtCtx) SetOformat(ofmt *OutputFmt) error {
 
 func (ctx *FmtCtx) Dump() {
 	if ctx.ofmt == nil {
-		C.av_dump_format(ctx.avCtx, 0, &(ctx.avCtx.filename[0]), 0)
+		C.av_dump_format(ctx.avCtx, 0, ctx.avCtx.url, 0)
 	} else {
-		C.av_dump_format(ctx.avCtx, 0, &(ctx.avCtx.filename[0]), 1)
+		C.av_dump_format(ctx.avCtx, 0, ctx.avCtx.url, 1)
 	}
 }
 

--- a/frame_go112.go
+++ b/frame_go112.go
@@ -124,7 +124,7 @@ func (f *Frame) Height() int {
 }
 
 func (f *Frame) PktPts() int64 {
-	return int64(f.avFrame.pkt_pts)
+	return int64(f.avFrame.pts)
 }
 
 func (f *Frame) PktPos() int64 {
@@ -132,7 +132,7 @@ func (f *Frame) PktPos() int64 {
 }
 
 func (f *Frame) SetPktPts(val int64) {
-	f.avFrame.pkt_pts = (C.int64_t)(val)
+	f.avFrame.pts = (C.int64_t)(val)
 }
 
 func (f *Frame) PktDts() int {
@@ -305,8 +305,6 @@ var frameSideDataTypes []uint32 = []uint32{
 	C.AV_FRAME_DATA_MASTERING_DISPLAY_METADATA,
 	C.AV_FRAME_DATA_MATRIXENCODING,
 	C.AV_FRAME_DATA_MOTION_VECTORS,
-	C.AV_FRAME_DATA_QP_TABLE_DATA,
-	C.AV_FRAME_DATA_QP_TABLE_PROPERTIES,
 	C.AV_FRAME_DATA_REGIONS_OF_INTEREST,
 	C.AV_FRAME_DATA_REPLAYGAIN,
 	C.AV_FRAME_DATA_S12M_TIMECODE,

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/3d0c/gmf
+module github.com/reijnenhhfm/gmf
 
 go 1.12
 

--- a/stream.go
+++ b/stream.go
@@ -45,7 +45,7 @@ func (s *Stream) DumpContexCodec(codec *CodecCtx) {
 }
 
 func (s *Stream) SetCodecFlags() {
-	s.avStream.codec.flags |= C.AV_CODEC_FLAG_GLOBAL_HEADER
+	s.avStream.event_flags |= C.AV_CODEC_FLAG_GLOBAL_HEADER
 }
 
 // CodecCtx
@@ -57,7 +57,7 @@ func (s *Stream) CodecCtx() *CodecCtx {
 	}
 
 	// Open input codec context
-	c, err := FindDecoder(int(s.avStream.codec.codec_id))
+	c, err := FindDecoder(int(s.avStream.codecpar.codec_id))
 	if err != nil {
 		return nil
 	}
@@ -75,7 +75,7 @@ func (s *Stream) CodecCtx() *CodecCtx {
 		panic("error opening codec context")
 	}
 
-	s.cc.avCodecCtx.time_base = s.avStream.codec.time_base
+	s.cc.avCodecCtx.time_base = s.avStream.time_base
 
 	return s.cc
 }


### PR DESCRIPTION
added a couple additions to the fork of dubrsl/gmf to make gmf compatible with FFmpeg 5.1
see issue [3d0c#152](https://github.com/3d0c/gmf/issues/152)